### PR TITLE
Made the change to ignore errors

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,6 +19,12 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
This pull request includes a small change to the `next.config.ts` file. The change configures the Next.js application to ignore TypeScript build errors and ESLint warnings during builds.

Configuration updates:

* [`next.config.ts`](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bR22-R27): Added `typescript` and `eslint` configurations to ignore build errors and warnings respectively.